### PR TITLE
Get process names with ps syntax instead of grep

### DIFF
--- a/pidswallow
+++ b/pidswallow
@@ -28,7 +28,7 @@ cpid=$(xprop _NET_WM_PID -id "$cwid" 2>/dev/null); xprop_ret="$?"
 [ "$xprop_ret" -ne 0 ] && vomit "$cwid" && exit
 
 cpid="${cpid##* }"
-cname="$(ps -e | grep "$cpid")"; cname="${cname##* }"
+cname="$(ps -p $cpid -o comm=)"
 while ppid="$(sed -n 's/^PPid:[ \t]*\(.*\)/\1/p' /proc/$cpid/status)"; do
     [ "$ppid" = 0 ] && exit 1 # looped to the top, no swallowable was found
     pname="$(ps -p $ppid -o comm=)"


### PR DESCRIPTION
It's safer than using `grep`, and according to [this](https://superuser.com/a/632987/1047393), the `ps` way is also POSIX compliant.

Note about this PR: As I said before, I'm pretty new to git/github, so I'm not sure if this is the right way to do it! This seems like such a small change (although I was planning to add more changes to this previously, but changed my mind), it doesn't feel like it's worth its own PR. I hope this is fine though!

And thank you again for this script, it made my experience with a tiling WM so much better!