### PR TITLE
Use the non-POSIX `local` keyword

### DIFF
--- a/pidswallow
+++ b/pidswallow
@@ -19,6 +19,7 @@ blacklist=" $swallowable octave-gui python "
 verbose=0
 
 vomit() {
+        local cwid pwid
         # focuses parent if child is dead.
         cwid="$1"
         [ -f "/tmp/swallowed-by-$cwid" ] || return 1
@@ -27,10 +28,10 @@ vomit() {
         xprop -id "$cwid" >/dev/null 2>&1 || bspc node "$pwid" -f #*
         [ "$verbose" -eq 1 ] && echo "$cwid vomited $pwid"
         rm "/tmp/swallowed-by-$cwid"
-        unset cwid pwid
 }
 
 swallow() {
+        local cwid pwid cname pname ppid cpid
         # return values
         # 0 -> Found and swallowed
         # 1 -> No swallow able  node found.
@@ -53,11 +54,10 @@ swallow() {
         bspc node "$pwid" --flag hidden=on                      #*
         [ "$verbose" -eq 1 ] && echo "$cname($cwid) swallowed $pname($pwid)"
         echo "$pwid" > "/tmp/swallowed-by-$cwid"
-        unset cwid pwid cname pname ppid cpid
 }
 
 toggle() {
-        cwid="$1"
+        local cwid="$1"
         if [ -f "/tmp/swallowed-by-$cwid" ]; then
                 swallow "$cwid"
                 vomit "$cwid"


### PR DESCRIPTION
It's a quick fix for variables left behind in [any scenario](https://github.com/Liupold/pidswallow/commit/97ae9bc8baf6419aff4c7e9acef7bec4cd39071e#commitcomment-40573792).

More info:
> even the most primitive POSIX-compliant shell I know of which is used by some GNU/Linux distributions as the /bin/sh default, dash (Debian Almquist Shell), supports it. FreeBSD and NetBSD use ash, the original Almquist Shell, which also supports it. OpenBSD uses a ksh implementation for /bin/sh which also supports it. So unless you're aiming to support non-GNU non-BSD systems like Solaris, or those using standard ksh, etc., you could get away with using local. (Might want to put some comment right at the start of the script, below the shebang line, noting that it is not strictly a POSIX sh script. Just to be not evil.) Having said all that, you might want to check the respective man-pages of all these sh implementations that support local, since they might have subtle differences in how exactly they work.

from [this stackoverflow answer](https://stackoverflow.com/a/18600920/6791873)

I also read about some [differences between shells](https://unix.stackexchange.com/a/493743/328615). My conclusion is that it'll work fine for our use case, as long as it's used sparingly.

Feel free to reject this if you want to stick to POSIX though!